### PR TITLE
Adds feature to copy executable

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::Subcommand;
 
 #[derive(Subcommand)]
-pub enum Commands {
+pub enum CellarCommand {
     Add {
         exe: String,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::{process::Command, env, fs, path::Path};
+use std::os::unix::fs::symlink;
 
 use clap::Parser;
 use cli::*;
@@ -9,26 +10,35 @@ fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Add { exe } => {
-            println!("Adding {}", exe);
+        CellarCommand::Add { exe } => {
             let home = env::var("HOME").expect("Unable to read $HOME");
             let command_name = Path::new(&exe)
                 .file_name().expect("Unable to access executable")
                 .to_str().expect("Unable to read executable name").to_string();
-            let output = fs::copy(exe, format!("{}/.config/cellar/scripts/{}", home, command_name));
+            let exe = fs::canonicalize(exe).expect("Unable to get absolute path to executable");
+            let to = format!("{}/.config/cellar/scripts/{}", home, command_name);
+            let _ = fs::remove_file(&to);
+            match cli.copy {
+                true => {
+                    let _ = fs::copy(exe, to).expect("Error copying executable");
+                },
+                false => {
+                    let _ = symlink(exe,to).expect("Error symlinking executable");
+                },
+
+            };
         },
-        Commands::Run { command_name } => {
-            let home = env::var("HOME").expect("Unable to read $HOME");
+        CellarCommand::Run { command_name } => {
             let output = Command::new(cellar_config(format!("/scripts/{}", command_name)))
                 .output()
                 .expect("Failed to execute command");
             println!("output: {}", String::from_utf8(output.stdout).expect("Failed to read output"));
         },
-        Commands::Remove { command_name } => {
+        CellarCommand::Remove { command_name } => {
             let _ = fs::remove_file(cellar_config(format!("/scripts/{}", command_name)));
         },
-        Commands::Init {  } => {
-            fs::create_dir_all(format!("{}/scripts", cellar_config("scripts")))
+        CellarCommand::Init {  } => {
+            fs::create_dir_all(cellar_config("scripts"))
             .expect("Unable to create ~/.config/cellar/scripts/");
             println!("Created ~/.config/cellar/scripts/");
         }
@@ -40,15 +50,18 @@ where
     S: ToString,
 {
     let home = env::var("HOME").expect("Unable to read $HOME");
-    format!("{}/.config/cellar/", home)
+    format!("{}/.config/cellar/{}", home, dir.to_string())
 }
 
 #[derive(Parser)]
 #[command(name = "Cellar", about, author, version)]
 pub struct Cli {
     #[command(subcommand)]
-    command: Commands,
+    command: CellarCommand,
 
-    #[arg(default_value_t = format!(""))]
+    #[arg(short, long, default_value_t = format!(""))]
     path: String,
+
+    #[arg(short, long, default_value_t = false)]
+    copy: bool,
 }


### PR DESCRIPTION
Defaults to symbolic linking file so it's not necessary to re-add after editing renames Commands to CellarCommand